### PR TITLE
os-x port: configury improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,8 +70,10 @@ AC_CHECK_LIB(dl, dlopen, [],
 dnl Checks for libraries
 AC_CHECK_LIB(pthread, pthread_mutex_init, [],
     AC_MSG_ERROR([pthread_mutex_init() not found.  libfabric requires libpthread.]))
-dnl AC_CHECK_LIB(rt, clock_gettime, [],
-dnl    AC_MSG_ERROR([clock_gettime() not found.  libfabric requires librt.]))
+    AC_SEARCH_LIBS([clock_gettime],[rt posix4],
+                 [AC_DEFINE([HAVE_CLOCK_GETTIME], [1],
+                            [Define to 1 if have clock_gettime.])
+                 ],[],[])
 
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)

--- a/src/clock_gettime_w.c
+++ b/src/clock_gettime_w.c
@@ -1,3 +1,39 @@
+/*
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "fi.h"
+
+#if !defined (HAVE_CLOCK_GETTIME)
+
 #include "clock_gettime_w.h"
 
 int clock_gettime_w(clockid_t clk_id, struct timespec *tp) {
@@ -15,4 +51,5 @@ int clock_gettime_w(clockid_t clk_id, struct timespec *tp) {
 
 	return retval;
 }
+#endif
 

--- a/src/common.c
+++ b/src/common.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
  * Copyright (c) 2006 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Intel Corp., Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +50,7 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 
-#ifdef __APPLE__
+#if !defined (HAVE_CLOCK_GETTIME)
 #include "clock_gettime_w.h"
 #define clock_gettime clock_gettime_w
 #endif


### PR DESCRIPTION
Improve check for support of clock_gettime.  Use conditional
for determining whether to use an internal clock_gettime feature
or to use the one provided by the system.

Add copyrights.

@bturrubiates here some config changes + copyrights
