### PR TITLE
configury:  add check for attribute alias support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,23 @@ if test x$ac_cv_asm_symver_support = xyes; then
 	AC_DEFINE([HAVE_SYMVER_SUPPORT], 1, [assembler has .symver support])
 fi
 
+AC_CACHE_CHECK(
+  [for alias attribute support],
+  [ac_cv_prog_cc_alias_symbols],
+  [AC_LINK_IFELSE(
+    [AC_LANG_SOURCE[
+        int foo(int arg);
+         int foo(int arg) { return arg + 3; };
+         int foo2(int arg) __attribute__ (( __alias__("foo")));
+      ]],
+    [ac_cv_prog_cc_alias_symbols="yes"],
+    [ac_cv_prog_cc_alias_symbols="no"])])
+
+if test "$ac_cv_prog_cc_alias_symbols" = yes; then
+  AC_DEFINE([HAVE_ALIAS_ATTRIBUTE], [1],
+            [Define to 1 if the linker supports alias attribute.])
+fi
+
 dnl Provider-specific checks
 FI_PROVIDER_INIT
 FI_PROVIDER_SETUP([psm])

--- a/include/fi.h
+++ b/include/fi.h
@@ -220,6 +220,12 @@ int fi_rma_target_allowed(uint64_t caps);
 
 #define DEFAULT_ABI "FABRIC_1.0"
 
+#ifdef  HAVE_ALIAS_ATTRIBUTE
+#define default_symver_pre(a) a##_
+#else
+#define default_symver_pre(a) a
+#endif
+
 /* symbol -> external symbol mappings */
 #ifdef HAVE_SYMVER_SUPPORT
 
@@ -229,8 +235,12 @@ int fi_rma_target_allowed(uint64_t caps);
         asm(".symver " #name "," #api "@@" DEFAULT_ABI)
 #else
 #  define symver(name, api, ver)
+#ifdef  HAVE_ALIAS_ATTRIBUTE
 #  define default_symver(name, api) \
-        extern __typeof(name) api __attribute__((alias(#name)))
+        extern typeof (name) api __attribute__((alias(#name)));
+#else
+#  define default_symver(name, api)
+#endif  /* HAVE_ALIAS_ATTRIBUTE */
 
 #endif /* HAVE_SYMVER_SUPPORT */
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -244,7 +244,7 @@ static struct fi_prov *fi_getprov(const char *prov_name)
 }
 
 __attribute__((visibility ("default")))
-void fi_freeinfo_(struct fi_info *info)
+void default_symver_pre(fi_freeinfo)(struct fi_info *info)
 {
 	struct fi_info *next;
 
@@ -271,7 +271,7 @@ void fi_freeinfo_(struct fi_info *info)
 default_symver(fi_freeinfo_, fi_freeinfo);
 
 __attribute__((visibility ("default")))
-int fi_getinfo_(uint32_t version, const char *node, const char *service,
+int default_symver_pre(fi_getinfo)(uint32_t version, const char *node, const char *service,
 	       uint64_t flags, struct fi_info *hints, struct fi_info **info)
 {
 	struct fi_prov *prov;
@@ -322,7 +322,7 @@ int fi_getinfo_(uint32_t version, const char *node, const char *service,
 default_symver(fi_getinfo_, fi_getinfo);
 
 __attribute__((visibility ("default")))
-struct fi_info *fi_dupinfo_(const struct fi_info *info)
+struct fi_info *default_symver_pre(fi_dupinfo)(const struct fi_info *info)
 {
 	struct fi_info *dup;
 
@@ -419,7 +419,7 @@ fail:
 default_symver(fi_dupinfo_, fi_dupinfo);
 
 __attribute__((visibility ("default")))
-int fi_fabric_(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
+int default_symver_pre(fi_fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
 {
 	struct fi_prov *prov;
 
@@ -438,7 +438,7 @@ int fi_fabric_(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *co
 default_symver(fi_fabric_, fi_fabric);
 
 __attribute__((visibility ("default")))
-uint32_t fi_version_(void)
+uint32_t default_symver_pre(fi_version)(void)
 {
 	return FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
 }
@@ -460,7 +460,7 @@ static const char *const errstr[] = {
 };
 
 __attribute__((visibility ("default")))
-const char *fi_strerror_(int errnum)
+const char *default_symver_pre(fi_strerror)(int errnum)
 {
 	if (errnum < FI_ERRNO_OFFSET)
 		return strerror(errnum);

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -493,7 +493,7 @@ static void fi_tostr_version(char *buf)
 }
 
 __attribute__((visibility ("default")))
-char *fi_tostr_(const void *data, enum fi_type datatype)
+char *default_symver_pre(fi_tostr)(const void *data, enum fi_type datatype)
 {
 	static char *buf = NULL;
 	uint64_t val64 = *(const uint64_t *) data;


### PR DESCRIPTION
OS-X doesn't support aliasing with strong symbols.
This commit adds support for detecting lack of
such support on a platform.  Solution for mac
is to disable the aliasing feature and not use
fi_getinfo_ etc.

Conflicts:
    include/fi.h
    src/fabric.c

Signed-off-by: Howard Pritchard howardp@lanl.gov
